### PR TITLE
Eslint rules update

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -68,8 +68,6 @@ export default [
                 },
             ],
 
-            "max-params": ["error", 3],
-
             "id-denylist": ["error", "cb", "item", "i", "el"],
 
             "padding-line-between-statements": [
@@ -108,8 +106,6 @@ export default [
                     next: ["case", "default", "return"],
                 },
             ],
-
-            "func-style": ["error", "expression"],
         },
     },
     {
@@ -125,4 +121,3 @@ export default [
         },
     },
 ];
-

--- a/src/plugins/swagger.ts
+++ b/src/plugins/swagger.ts
@@ -35,7 +35,6 @@ const configureSwagger = async (fastify: FastifyInstance) => {
 
     if (docsPassword) {
         await fastify.register(fastifyBasicAuth, {
-            // eslint-disable-next-line max-params
             validate(username, password, _req, _reply, done) {
                 if (
                     username === basicAuthUsername &&


### PR DESCRIPTION
## Summary:

This pull request primarily focuses on simplifying the ESLint configuration by removing unused or unnecessary rules and cleaning up comments in the codebase. Additionally, it removes an inline ESLint directive in the Swagger plugin file.

### ESLint Configuration Cleanup:

* Removed the `"max-params"` rule, which restricted the number of parameters in functions to 3.
* Removed the `"func-style"` rule, which enforced function style as expressions.

### Code Cleanup in Swagger Plugin:

* Removed an inline ESLint directive (`// eslint-disable-next-line max-params`) in the `validate` function of the Swagger plugin, as the `"max-params"` rule was removed from the ESLint configuration.