### PR TITLE
feat(logging): map Pino log levels to GCP Cloud Logging severity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,29 @@ export default [
             semi: ["error", "always"],
 
             "no-console": "warn",
+
+            // log.trace()/log.debug() are suppressed in GCP (logger level is
+            // 'info'), so they never reach Cloud Logging yet add noise. Flag
+            // them so they aren't committed. `warn` keeps CI/commits green for
+            // the existing intentional debug calls.
+            "no-restricted-syntax": [
+                "warn",
+                {
+                    // log.trace() / log.debug() — direct logger reference
+                    selector:
+                        "CallExpression[callee.object.name=/^(log|logger)$/][callee.property.name=/^(trace|debug)$/]",
+                    message:
+                        "log.trace()/log.debug() are suppressed in GCP (logger level is 'info') and add noise — use log.info() or higher, or remove before committing.",
+                },
+                {
+                    // *.log.trace() / *.log.debug() — request.log, fastify.log, this.log
+                    selector:
+                        "CallExpression[callee.object.property.name='log'][callee.property.name=/^(trace|debug)$/]",
+                    message:
+                        "log.trace()/log.debug() are suppressed in GCP (logger level is 'info') and add noise — use log.info() or higher, or remove before committing.",
+                },
+            ],
+
             "no-param-reassign": "error",
             "default-case": "off",
             "consistent-return": "off",

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,30 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// GCP Cloud Logging reads a string `severity` field; Pino emits a numeric
+// `level`, so without this mapping every entry shows up as INFO.
+// https://github.com/pinojs/pino/blob/main/docs/help.md#mapping-pino-log-levels-to-google-cloud-logging-stackdriver-severity-levels
+const pinoLevelToGcpSeverity: Record<string, string> = {
+    trace: "DEBUG",
+    debug: "DEBUG",
+    info: "INFO",
+    warn: "WARNING",
+    error: "ERROR",
+    fatal: "CRITICAL",
+};
+
+const gcpLogger = {
+    messageKey: "message",
+    formatters: {
+        level(label: string, number: number) {
+            return {
+                severity: pinoLevelToGcpSeverity[label] ?? "INFO",
+                level: number,
+            };
+        },
+    },
+};
+
 const envToLogger = {
     development: {
         transport: {
@@ -17,7 +41,7 @@ const envToLogger = {
             },
         },
     },
-    production: true,
+    production: gcpLogger,
     test: {
         transport: {
             target: "pino-pretty",
@@ -35,7 +59,7 @@ export const configureServer = async (): Promise<FastifyInstance> => {
         logger:
             envToLogger[
                 process.env.NODE_ENV as "development" | "production" | "test"
-            ] ?? true,
+            ] ?? gcpLogger,
     });
 
     try {


### PR DESCRIPTION
## Summary:

Makes the application logs render correctly in GCP Cloud Logging.

- **`src/server.ts`** — Adds a `gcpLogger` Pino config that maps Pino's numeric `level` to the string `severity` field that Cloud Logging expects (`trace`/`debug` → `DEBUG`, `info` → `INFO`, `warn` → `WARNING`, `error` → `ERROR`, `fatal` → `CRITICAL`) and sets `messageKey: "message"`. Without this, every entry was reported as `INFO` in Cloud Logging. The new config is used for the `production` environment and as the fallback when `NODE_ENV` is unrecognized.
- **`eslint.config.mjs`** — Adds a `no-restricted-syntax` rule that warns on `log.trace()` / `log.debug()` calls (including `request.log`, `fastify.log`, `this.log` forms). These levels are suppressed in GCP (logger level is `info`), so they never reach Cloud Logging and only add noise. Kept at `warn` so existing intentional debug calls don't break CI/commits.

## Issue ticket number and link:

## Testing:

- [x] Verified Pino emits a string `severity` field alongside the numeric `level` in production config.
- [x] Confirmed ESLint flags `log.trace()` / `log.debug()` calls as warnings.

## Dependencies:

None.

## Dev checklist:

- [x] I have performed a self-review of my code.
- [x] I have manually tested this feature to ensure I am not breaking a critical piece of the platform.
